### PR TITLE
removed unused variable that was preventing execution

### DIFF
--- a/kirshenbaum.py
+++ b/kirshenbaum.py
@@ -6,8 +6,6 @@ from __future__ import division, print_function
 import re
 
 PHONEMIC_RE = re.compile(r'/[^/]+/')
-PHONETIC_RE = re.compile(r'\[[^\]+\]')
-
 
 def _sort(it):
   """Sort by reverse-length, then alphabetically"""


### PR DESCRIPTION
The PHONETIC_RE variable is an incorrectly built regex and prevents python from executing the script:

```
Traceback (most recent call last):
  File "kirshenbaum.py", line 9, in <module>
    PHONETIC_RE = re.compile(r'\[[^\]+\]')
....
sre_constants.error: unexpected end of regular expression

```

Since the variable is not used anyway, this just removes it so it can be run
